### PR TITLE
Add state-dependant samplers

### DIFF
--- a/core/src/main/scala/com/eharmony/spotz/optimizer/hyperparam/GuidedChoice.scala
+++ b/core/src/main/scala/com/eharmony/spotz/optimizer/hyperparam/GuidedChoice.scala
@@ -1,0 +1,17 @@
+package com.eharmony.spotz.optimizer.hyperparam
+
+import scala.util.Random
+
+abstract class GuidedChoice[K, T](key: String) extends RandomSamplerWithState[T] {
+  protected def guide(m: Map[String, Any]): K = m(key).asInstanceOf[K]
+}
+
+case class IndexedChoice[K, T](key: String, values: Map[K, Vector[T]]) extends GuidedChoice[K, T](key) {
+  private val choices = values.mapValues(xs => RandomChoice(xs))
+
+  def apply(rng: Random, m: Map[String, Any]): T = choices(guide(m))(rng)
+}
+
+case class TransformedChoice[K, T](key: String, transform: K => T) extends GuidedChoice[K, T](key) {
+  def apply(rng: Random, m: Map[String, Any]): T = transform(guide(m))
+}

--- a/core/src/main/scala/com/eharmony/spotz/optimizer/hyperparam/RandomSampler.scala
+++ b/core/src/main/scala/com/eharmony/spotz/optimizer/hyperparam/RandomSampler.scala
@@ -14,5 +14,10 @@ trait RandomSampler[T] extends Serializable {
   def apply(rng: Random): T
 }
 
+trait RandomSamplerWithState[T] extends RandomSampler[T] {
+  def apply(rng: Random, params: Map[String, _]): T
+  def apply(rng: Random) = apply(rng, Map.empty[String, Any])
+}
+
 trait CombinatoricRandomSampler[T] extends RandomSampler[Iterable[Iterable[T]]]
 trait IterableRandomSampler[T] extends RandomSampler[Iterable[T]]

--- a/examples/src/main/scala/com/eharmony/spotz/examples/WithStateExample.scala
+++ b/examples/src/main/scala/com/eharmony/spotz/examples/WithStateExample.scala
@@ -1,0 +1,39 @@
+package com.eharmony.spotz.examples
+
+import com.eharmony.spotz.Preamble.Point
+import com.eharmony.spotz.objective.Objective
+import com.eharmony.spotz.optimizer.hyperparam.{UniformInt, IndexedChoice, RandomSamplerWithState}
+import com.eharmony.spotz.optimizer.{OptimizerResult, StopStrategy}
+
+import scala.math._
+import scala.util.Random
+
+class WithStateObjective extends Objective[Point, Double] {
+  override def apply(point: Point): Double = point.get[Int]("x1") * 1000 + point.get[Char]("x2").toDouble
+}
+
+trait WithStateExample {
+  val objective = new WithStateObjective
+  val stop = StopStrategy.stopAfterMaxTrials(5000000)
+  val numBatchTrials = 500000
+
+  def apply(): OptimizerResult[Point, Double]
+
+  def main(args: Array[String]) {
+    val result = apply()
+    println(result)
+  }
+}
+
+trait WithStateRandomSearch extends WithStateExample with RandomSearchRunner with ExampleRunner {
+  val hyperParameters = Map(
+    ("x1", UniformInt(1, 3)),
+    ("x2", IndexedChoice("x1", Map[Int, Vector[Char]](
+      (1 -> Vector('g', 'h', 'i')),
+      (2 -> Vector('d', 'e', 'f')),
+      (3 -> Vector('a', 'b', 'c'))
+    )))
+  )
+}
+
+object WithStateParRandomSearch extends WithStateRandomSearch with ParExampleRunner

--- a/examples/src/test/scala/com/eharmony/spotz/examples/WithStateTest.scala
+++ b/examples/src/test/scala/com/eharmony/spotz/examples/WithStateTest.scala
@@ -1,0 +1,27 @@
+package com.eharmony.spotz.examples
+
+import com.eharmony.spotz.Preamble.Point
+import org.junit.Assert._
+import org.junit.Test
+
+import scala.math.Pi
+
+class WithStateTest {
+  @Test
+  def testBraninParRandomSearch() {
+    val result = WithStateParRandomSearch()
+    checkAssertions(result.bestPoint, result.bestLoss)
+  }
+
+  def checkAssertions(p: Point, l: Double) {
+    val i = (l / 1000).toInt
+    val d = l % 1000
+    val c = d.asInstanceOf[Char]
+    val map = Map[Int, Vector[Char]](
+      (1 -> Vector('g', 'h', 'i')),
+      (2 -> Vector('d', 'e', 'f')),
+      (3 -> Vector('a', 'b', 'c'))
+    )
+    assertTrue(s"Value $i does not correspond to char $c ($d)", map(i).contains(c))
+  }
+}


### PR DESCRIPTION
You can now declare a sampler using RandomSamplerWithState.
It is the
same as a normal RandomSampler, except it is able to access previous
hyperparameters.

This allows for a param x1 to depend on the value of x0.

---------------

Hi,

Here is a PR for something that we found necessary in our use of spotz.
The implementation is rather bare-bones – it's but a first version that passes the (added) test.

We'd be interested in feedback for the PR or for the feature itself.

Thanks!